### PR TITLE
PTR config option and Uploading code log message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-screeps",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rollup-plugin-screeps.ts
+++ b/src/rollup-plugin-screeps.ts
@@ -9,11 +9,12 @@ export interface ScreepsConfig {
   token?: string
   email?: string
   password?: string
-  protocol: "http" | "https",
-  hostname: string,
-  port: number,
-  path: string,
+  protocol: "http" | "https"
+  hostname: string
+  port: number
+  path: string
   branch: string | "auto"
+  ptr?: number
 }
 
 export interface ScreepsOptions{
@@ -97,6 +98,8 @@ export function uploadSource(config: string | ScreepsConfig, options: OutputOpti
 
     let api = new ScreepsAPI(config)
 
+    console.log(`Uploading code to ${getServerLabel(config)} server`);
+
     if(!config.token){
       api.auth().then(() => {
         runUpload(api, branch!, code)
@@ -135,6 +138,17 @@ export function getBranchName(branch: string) {
   } else {
     return branch
   }
+}
+
+function getServerLabel(config: ScreepsConfig) {
+  if (config.hostname === 'screeps.com') {
+    let label = 'Official'
+    if (config.ptr) {
+      label += ' PTR'
+    }
+    return label
+  }
+  return 'Private'
 }
 
 const ex = (x: any) => JSON.stringify(x, null, 2);


### PR DESCRIPTION
I added an option config option for `ptr: number`

I also added a console message to the `uploadSource()` method to describe where the code will be uploaded. Available messages are:
* Uploading code to Private server
* Uploading code to Official server
* Uploading code to Official PTR server

This change relates to a merge request I submitted for node-screeps-api, to also add the `ptr` config option there:
* https://github.com/screepers/node-screeps-api/pull/53